### PR TITLE
Fix `README.md`'s and `template.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,33 @@
-![2](https://user-images.githubusercontent.com/73081144/134788873-c1401000-5fe5-45da-8902-96891c218d69.png)
+![spellbook](https://user-images.githubusercontent.com/73081144/134788873-c1401000-5fe5-45da-8902-96891c218d69.png)
 
 # Spellbook
 
-This repo aims to optimize usability of DL techniques by implementing a standardized code piece suitable to various DL tasks such as classification, object detection, etc. By directly importing the code piece the learning canvas may be built rather fast and allow engineers to focus on task-specific issues rather than cross-task, reusable actions.
+This repo aims to optimize usability of DL techniques by implementing a
+standardized code piece suitable to various DL tasks such as classification,
+object detection, etc.
 
-## File List
+By directly importing the code piece the learning canvas may be built rather
+fast and allow engineers to focus on task-specific issues rather than
+cross-task, reusable actions.
 
-### `callbacks.py`
+## Spellbook Contents
 
-Custom callbacks
+The table below contains the descriptions for each of the scripts this repo
+provides:
 
-### `generatorInstance.py`
-
-Initializes batches of features and targets by iterating through filenames (obsolete)
-
-### `globalVariables.py`
-
-Space where all used variables are stored
-
-### `helpers.py`
-
-Useful miscellaneous functions
-
-### `losses.py`
-
-Custom loss functions
-
-### `magic.py`
-
-Working file, used to initialize parameters and start training
- 
-### `metrics.py`
-
-Custom metrics
-
-### `models.py`
-
-Custom models as well as downloaded ones, such as *ImageNet* models
-
-### `optimizers.py`
-
-Custom optimizers
-
-### `permutationFunctions.py`
-
-Data permutation functions
-
-### `prepareTrainDataset.py`
-
-Dataset preparation functions (initializes tf.data.Dataset object and does permutations)
-
-### `preprocessData.py`
-
-Prepares data for training (e.x. normalization, rescailing, resizing, etc.)
-
-### `preprocessingFunctions.py`
-
-Data preprocessing functions
-
-### `train.py` 
-
-Takes data as a parameter and trains a given model on it
+| Script                      | Description                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `callbacks.py`              | Custom callbacks for `Keras` library                                                                  |
+| `generatorInstance.py`      | (deprecated script / to be deleted)                                                                   |
+| `globalVariables.py`        | Global variables and parameters such as data shapes, learning rate decay, etc.                        |
+| `helpers.py`                | Miscellaneous functions                                                                               |
+| `losses.py`                 | Custom loss functions                                                                                 |
+| `magic.py`                  | Main wrapper used to fit given models with given parameters and data                                  |
+| `metrics.py`                | Custom metrics                                                                                        |
+| `models.py`                 | Custom models as well as pre-trained `Tensorflow` models (such as _ImageNet_)                         |
+| `optimizers.py`             | Custom optimizers                                                                                     |
+| `permutationFunctions.py`   | Functions for data permutations                                                                       |
+| `prepareTrainDataset.py`    | Functions to prepare datasets (initialization of `tf.data.Dataset` object with optional permutations) |
+| `preprocessData.py`         | Wrapper to preprocess data (such as normalization, rescailing, resizing, etc.)                        |
+| `preprocessingFunctions.py` | Functions for data preprocessing                                                                      |
+| `train.py`                  | Collection of train steps and full complete train cycles                                              |

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,15 +1,4 @@
-# Projects Directory
+# Project Directory
 
-Directory that contains personal projects and competitions from [Kaggle.com](https://www.kaggle.com/).
-
-Each project directory consists of following folders:
-
- - `datasets` - contains project datasets and metadata files;
- - `training` - contains trained models' weights and training logs;
- - `best_weights` - contains the best models' weights picked from `training` directory (used for ensemble and prediction);
- - `predictions` - contains predictions for *test* dataset (usually used for score checking on [Kaggle.com](https://www.kaggle.com/) for corresponding competitions).
-
-and `.py` files:
-
- - `dataPreprocessing.py` - script to transform data into general representation appropriate for fitting (data is saved to `datasets` directory);
- - `prediction.py` - script to prepare and save predictions into `predictions` directory.
+This directory contains projects to solve competitions at
+[Kaggle.com](https://www.kaggle.com/).

--- a/projects/exoplanet_hunting/README.md
+++ b/projects/exoplanet_hunting/README.md
@@ -2,23 +2,34 @@
 
 ## Description
 
-The data describe the change in flux (light intensity) of several thousand stars. Each star has a binary label of 2 or 1. 2 indicated that that the star is confirmed to have at least one exoplanet in orbit; some observations are in fact multi-planet systems.
+The data describe the change in flux (light intensity) of several thousand
+stars.
+Each star has a binary label of 2 or 1.
+2 indicates that that the star is confirmed to have at least one exoplanet in
+orbit; some observations are in fact multi-planet systems.
 
-As you can imagine, planets themselves do not emit light, but the stars that they orbit do. If said star is watched over several months or years, there may be a regular 'dimming' of the flux (the light intensity). This is evidence that there may be an orbiting body around the star; such a star could be considered to be a 'candidate' system. Further study of our candidate system, for example by a satellite that captures light at a different wavelength, could solidify the belief that the candidate can in fact be 'confirmed'.
+As you can imagine, planets themselves do not emit light, but the stars that
+they orbit do.
 
-&nbsp; 
+If a said star is watched over several months or years, there may be a regular
+'dimming' of the flux (the light intensity).
+This is evidence that there may be an orbiting body around the star; such a star
+could be considered to be a 'candidate' system.
+Further study of our candidate system, for example, by a satellite that captures
+light at a different wavelength, could solidify the belief that the candidate
+can in fact be 'confirmed'.
 
 ## Data Preprocessing
 
-To deal with outliers, we simply replace each maximum and minimum values with average for each FLUX record.
-
-&nbsp; 
+To deal with outliers, we simply replace each maximum and minimum values with
+average for each FLUX record.
 
 ## Data Augmentation
 
-The peculiarity of this problem is that it has highly imbalanced training and test datasets. To deal with the problem, the SMOTE (oversampling) technique combined with random undersampling is used as per ([Chawla et al., 2002](https://arxiv.org/pdf/1106.1813.pdf)).
-
-&nbsp; 
+The peculiarity of this problem is that it has highly imbalanced training and
+test datasets. To deal with the problem, the SMOTE (oversampling) technique
+combined with random undersampling is used as per
+[Chawla et al., 2002](https://arxiv.org/pdf/1106.1813.pdf).
 
 ## Training
 
@@ -26,16 +37,23 @@ The peculiarity of this problem is that it has highly imbalanced training and te
 
 The following CNN architecture is used to achieve **perfect score (100%)**:
 
-* **Input layer**;
-* **1D convolutional layer**, consisting of 10 2x2 filters, L2 regularization and RELU activation function;
-* **1D max pooling layer**, window size - 2x2, stride - 2;
-* **Dropout** with 20% probability;
-* **Fully connected layer** with 32 neurons and RELU activation function;
-* **Dropout** with 40% probability;
-* **Fully connected layer** with 18 neurons and RELU activation function;
-* **Output layer** with sigmoid function.
+- **Input layer**;
+- **1D convolutional layer**, consisting of 10 2x2 filters, L2 regularization and RELU activation function;
+- **1D max pooling layer**, window size - 2x2, stride - 2;
+- **Dropout** with 20% probability;
+- **Fully connected layer** with 32 neurons and RELU activation function;
+- **Dropout** with 40% probability;
+- **Fully connected layer** with 18 neurons and RELU activation function;
+- **Output layer** with sigmoid function.
 
-As it is suggested in papers ([Hinton et al., 2021](https://arxiv.org/pdf/1207.0580.pdf), [Park & Kwak, 2016](http://mipal.snu.ac.kr/images/1/16/Dropout_ACCV2016.pdf)), we use 20% dropout after 1D CONV layers and 40-50% dropout after fully connected layers. For training, we initialized batch size to 64 and number of epochs to 30. Also, we use exponential decay and early stopping to prevent non-convergence and overfitting.
+As it is suggested in papers by
+[Hinton et al., 2021](https://arxiv.org/pdf/1207.0580.pdf) and
+[Park & Kwak, 2016](http://mipal.snu.ac.kr/images/1/16/Dropout_ACCV2016.pdf),
+we use 20% dropout after 1D CONV layers and 40-50% dropout after fully connected
+layers.
+For training, we initialized batch size to 64 and number of epochs to 30.
+Also, we use exponential decay and early stopping to prevent non-convergence and
+overfitting.
 
 ### Loss
 
@@ -45,10 +63,10 @@ Default binary-crossentropy loss function is used.
 
 Default adam optimizer is used.
 
-&nbsp; 
-
 ## Prediction
 
-Training on GPU involves a certain degree of randomness. On average, this model achieves a perfect score on y=1 (star has an exoplanet) around 20 times for every 200 simulations.
+Training on GPU involves a certain degree of randomness.
+On average, this model achieves a perfect score on y=1 (star has an exoplanet)
+around 20 times for every 200 simulations.
 
 ![image](https://user-images.githubusercontent.com/73081144/114321610-f0e3b380-9ad8-11eb-91b2-38526202d29d.png)

--- a/templates.md
+++ b/templates.md
@@ -89,7 +89,12 @@ The project's `README.md` complies with the following template:
 The `.csv` metadata complies with the following format:
 
 ```md
-- first column must be named `filenames` and contain strings as names of the images (does not matter if filenames have file extension at the end);
-- second column is `bboxes` and has a list of lists of bounding boxes which are stored in this format: `ymin, ymax, xmin, xmax`. Note: each bounding box must be NORMALIZED;
-- (optional) third column is `classes` which contains integers as classes for each image.
+- Column `A`:
+  - must be named `filenames`, and
+  - contain strings as names of the images (does not matter if filenames have file extension at the end),
+- Column `B`:
+  - must be named `bboxes`,
+  - has a list (`[]`) of lists of **normalized** bounding boxes the format `[ymin, ymax, xmin, xmax]`, and
+- _optional_ column `C`:
+  - is named `classes` and contains integers as classes for each image.
 ```

--- a/templates.md
+++ b/templates.md
@@ -40,9 +40,6 @@ def function(array, a=5.0,...):
 
 ## Repo Directory Structure
 
-The directories comply with the following template:
-
-```md
 Each project directory consists of following folders:
 
 | Folder         | Description                                           |
@@ -58,7 +55,6 @@ and the following `.py` scripts:
 | ---------------------- | ---------------------------------------------------------------------------------- |
 | `dataPreprocessing.py` | Preprocesses data for fitting (preprocessed data is saved to `datasets` directory) |
 | `prediction.py`        | Prepares and saves predictions into `predictions` directory                        |
-```
 
 ## Project `README` Template
 
@@ -88,7 +84,6 @@ The project's `README.md` complies with the following template:
 
 The `.csv` metadata complies with the following format:
 
-```md
 - Column `A`:
   - must be named `filenames`, and
   - contain strings as names of the images (does not matter if filenames have file extension at the end),
@@ -97,4 +92,3 @@ The `.csv` metadata complies with the following format:
   - has a list (`[]`) of lists of **normalized** bounding boxes the format `[ymin, ymax, xmin, xmax]`, and
 - _optional_ column `C`:
   - is named `classes` and contains integers as classes for each image.
-```

--- a/templates.md
+++ b/templates.md
@@ -1,8 +1,19 @@
-# Object Documentation
+# Templates
 
-The general template to describe Python objects is as follows
+This file contains templates and formats on how to structure and document
 
-```
+- [Python objects](#python-object-documentation) such as functions and classes,
+- [repo's directories](#repo-directory-structure) for proper render on GitHub,
+- [project's readme](#project-readme-template) to grasp the idea behind
+  the work done, and
+- [object detection metadata](#object-detection-metadata) for object detection
+  fit.
+
+## Python Object Documentation
+
+The general template to describe Python functions and classes is as follows:
+
+```py
 def function(array, a=5.0,...):
 
     """
@@ -21,74 +32,64 @@ def function(array, a=5.0,...):
     multiplied_array : ndarray
         product of numpy array and constant
     """
-    
+
     multiplied_array = array * a
 
     return multiplied_array
 ```
-# Project Directory File Architecture
 
-```
+## Repo Directory Structure
+
+The directories comply with the following template:
+
+```md
 Each project directory consists of following folders:
 
- - datasets - contains project datasets and metadata files
- - training - contains trained models' weights and training logs
- - best_weights - contains the best models' weights picked from `training` directory
- - predictions - contains predictions for *test* dataset
+| Folder         | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `datasets`     | Project datasets and metadata files                   |
+| `training`     | Trained models' weights and fit logs                  |
+| `best_weights` | Best models' weights picked from `training` directory |
+| `predictions`  | Predictions for test dataset                          |
 
-and `.py` files:
+and the following `.py` scripts:
 
- - `dataPreprocessing.py` - script to transform data into general representation appropriate for fitting (data is saved to `datasets` directory);
- - `prediction.py` - script to prepare and save predictions into `predictions` directory.
+| Script                 | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `dataPreprocessing.py` | Preprocesses data for fitting (preprocessed data is saved to `datasets` directory) |
+| `prediction.py`        | Prepares and saves predictions into `predictions` directory                        |
 ```
 
-# Project Description
+## Project `README` Template
 
-```
+The project's `README.md` complies with the following template:
+
+```md
 # Project Name
 
 ## Description
-- 
-
-&nbsp;
 
 ## Data Preprocessing
 
-- 
-
-&nbsp; 
-
 ## Data Augmentation
-
-- 
-
-&nbsp; 
 
 ## Training
 
 ### Models
-- 
 
 ### Loss
-- 
 
 ### Optimizer
-- 
-
-&nbsp; 
 
 ## Prediction
-- 
 ```
 
-# Object Detection Metadata
+## Object Detection Metadata
 
-```
-Metadata that you save as a .csv file must have following structure:
+The `.csv` metadata complies with the following format:
 
-    - first column must be named 'filenames' and contains strings as names of the images (does not matter if filenames have file extension at the end);
-
-    - second column is 'bboxes' and has a list of lists of bounding boxes which are stored in this format: ymin, ymax, xmin, xmax. Note: each bounding box should be NORMALIZED;
-
-    - (optional) third column is 'classes' which contains integers as classes for each image.
+```md
+- first column must be named `filenames` and contain strings as names of the images (does not matter if filenames have file extension at the end);
+- second column is `bboxes` and has a list of lists of bounding boxes which are stored in this format: `ymin, ymax, xmin, xmax`. Note: each bounding box must be NORMALIZED;
+- (optional) third column is `classes` which contains integers as classes for each image.
 ```


### PR DESCRIPTION
This PR introduces the following fixes:

- main `README.md` file is now
  - formatted
  - file list is converted to table instead of headings
  - script descriptions are rewritten
- `template.md` file is now
  - formatted
  - has better structure
  - has better wording
- `projects/README.md` is now
  - formatted
  - has some minor text amendments
- `projects/exoplanet_hunting/README.md` is now
  - formatted
  - has some minor text amendments

To see effect of this PR, navigate to `Files changed` above and then open `rich diff` as shown below:

![image](https://user-images.githubusercontent.com/19555629/135601020-043ad520-0650-4516-be97-0732db208c24.png)
